### PR TITLE
Multiprocessing support and timeouts

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 import random
 from DiceParser import DiceParser
+from concurrent.futures import ProcessPoolExecutor
 
 description = '''An example bot to showcase the discord.ext.commands extension
 module.
@@ -28,6 +29,7 @@ def processDice(dice):
     result = DP.evaluateInfix(dice.strip('` \n\t'))
     return result
 
+executor = ProcessPoolExecutor()
 
 @bot.command()
 async def roll(dice : str):
@@ -42,6 +44,7 @@ async def roll(dice : str):
     except ZeroDivisionError as err:
         result = err
     except Exception as err:
+        print(err)
         result = "An unhandled exception occured during operation."
     await bot.say(result)
 

--- a/main.py
+++ b/main.py
@@ -27,11 +27,8 @@ async def add(left : int, right : int):
 
 def processDice(dice):
     """A wrapper for running our DiceParser in a seperate procces"""
-    print("waiting on "+dice)
     DP = DiceParser()
     result = DP.evaluateInfix(dice)
-    print(result)
-    print("finished proccessing dice. This *should* be returning...")
     return result
 
 executor = ProcessPoolExecutor()
@@ -39,21 +36,17 @@ executor = ProcessPoolExecutor()
 @bot.command()
 async def roll(dice : str):
     """Rolls a dice using the custom DiceParser."""
-    result=None
-    startTime = bot.loop.time()
-    subprocess = bot.loop.run_in_executor(executor, processDice, dice)
-    while True:
-        if bot.loop.time() > startTime+10:
-            subprocess.cancel()
-            result = "Operation took longer than 10 seconds. Aborted."
-            break
-        try:
-            result = subprocess.result()
-            if subprocess.exception():
-                result = subprocess.exception()
-        except asyncio.InvalidStateError:
-            asyncio.sleep(0.10)
-    print(result)
+    try:
+        coro = bot.loop.run_in_executor(executor, processDice, dice)
+        result = await asyncio.wait_for(coro, timeout=10.0, loop=bot.loop)
+    except asyncio.TimeoutError:
+        result="Operation took longer than 10 seconds. Aborted."
+    except ValueError as err:
+        result = err
+    except ZeroDivisionError as err:
+        result = err
+    except Exception as err:
+        result = "An unhandled exception occured during operation."
     await bot.say(result)
 
 @bot.command(description='For when you wanna settle the score some other way')


### PR DESCRIPTION
Runs the dieroller in its own process, and kills it if it takes longer than 10 seconds to complete. Which should do a lot for stability.

Solves #5 